### PR TITLE
Feat automatic steam updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,15 @@ Feel free to overwrite these environment variables, using -e (--env):
 | RSDW_ADMINS          | string |                | Comma separated list of user ids |
 | RSDW_ADMIN_PASSWORD  | string | random         | Server admin password. |
 | RSDW_ADDITIONAL_ARGS | string |                | Additional CLI arguments to be passed into RSDragonwildsServer.sh |
+| RSDW_AUTO_STOP_ON_UPDATE | boolean | false | Set to lowercase `true` to stop the server when a new Steam build is detected. Restart behavior depends on your container runtime or orchestrator. |
 
 > [!NOTE]
 > - `RSDW_OWNER_ID` is **required** for server visibility/functionality  
 > - Environment variables with `random` default values are regenerated as random strings each time the container starts  
 > - Check the container’s standard output for the generated values  
 > - Explicitly setting these environment variables disables this behavior
+
+When Steam-based installs are used, the container can detect newer builds while the server is running. By default it only logs that an update is available; set `RSDW_AUTO_STOP_ON_UPDATE=true` to stop the server and rely on your restart policy or orchestrator to bring it back on the newer build.
 
 ## Debug Logging
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This image provides a convenient [RuneScape: Dragonwilds Server](https://store.s
 
 Running using Docker:
 ```console
-docker run -d --env RSDW_OWNER_ID=<userid_from_gameclient> --name=rsdw-dedicataed ghcr.io/runescape/rsdw-dedicated
+docker run -d --env RSDW_OWNER_ID=<userid_from_gameclient> --name=rsdw-dedicated ghcr.io/runescape/rsdw-dedicated
 ```
 
 ## System Requirements
@@ -38,7 +38,7 @@ docker volume create rsdw-dedicated
 
 ```console
 # Run with volume attached
-docker run -d -v rsdw-dedicated:/home/steam/rsdw-dedicated --env RSDW_OWNER_ID=<userid_from_gameclient> --name=rsdw-dedicataed ghcr.io/runescape/rsdw-dedicated
+docker run -d -v rsdw-dedicated:/home/steam/rsdw-dedicated --env RSDW_OWNER_ID=<userid_from_gameclient> --name=rsdw-dedicated ghcr.io/runescape/rsdw-dedicated
 ```
 
 # Configuration

--- a/sniper/Dockerfile
+++ b/sniper/Dockerfile
@@ -75,7 +75,7 @@ ENV RSDW_SERVER_NAME="rsdw-container" \
 # Set permissions on STEAMAPPDIR
 # Permissions may need to be reset if persistent volume mounted
 RUN set -x \
-        && apt-get install unzip gettext-base pwgen\
+        && apt-get -y install unzip gettext-base pwgen jq\
 	&& mkdir -p "${STEAMAPPDIR}" \
 	&& chmod +x "/entry.sh" \
         && chown -R "${PUID}:${PGID}" "${STEAMAPPDIR}" \

--- a/sniper/Dockerfile
+++ b/sniper/Dockerfile
@@ -69,8 +69,7 @@ ENV RSDW_SERVER_NAME="rsdw-container" \
     RSDW_ADMINS="" \
     RSDW_ADMIN_PASSWORD="random" \
     RSDW_PORT=7777 \
-    RSDW_ADDITIONAL_ARGS="" \
-    RSDW_OWNER_ID=""
+    RSDW_ADDITIONAL_ARGS=""
 
 # Set permissions on STEAMAPPDIR
 # Permissions may need to be reset if persistent volume mounted
@@ -81,7 +80,7 @@ RUN set -x \
         && mkdir -p "${STEAMAPPDIR}" \
         && chmod +x "/entry.sh" \
         && chown -R "${PUID}:${PGID}" "${STEAMAPPDIR}" \
-        && chmod 0777 "${STEAMAPPDIR}"
+        && chmod 0755 "${STEAMAPPDIR}"
 
 # Switch to user
 USER ${PUID}:${PGID}

--- a/sniper/Dockerfile
+++ b/sniper/Dockerfile
@@ -75,9 +75,11 @@ ENV RSDW_SERVER_NAME="rsdw-container" \
 # Set permissions on STEAMAPPDIR
 # Permissions may need to be reset if persistent volume mounted
 RUN set -x \
-        && apt-get -y install unzip gettext-base pwgen jq\
-	&& mkdir -p "${STEAMAPPDIR}" \
-	&& chmod +x "/entry.sh" \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends unzip gettext-base pwgen jq \
+        && rm -rf /var/lib/apt/lists/* \
+        && mkdir -p "${STEAMAPPDIR}" \
+        && chmod +x "/entry.sh" \
         && chown -R "${PUID}:${PGID}" "${STEAMAPPDIR}" \
         && chmod 0777 "${STEAMAPPDIR}"
 

--- a/sniper/app/entry.sh
+++ b/sniper/app/entry.sh
@@ -4,8 +4,8 @@
 set -e
 
 # Globals
-STEAMCMD_API="https://api.steamcmd.net/v1/info"
-STEAM_DEPOT_BRANCH="public"
+STEAM_UPTODATECHECK_API="https://api.steampowered.com/ISteamApps/UpToDateCheck/v1/"
+STEAM_UPDATE_CHECK_INTERVAL_SECONDS=1800
 
 # Functions
 
@@ -29,6 +29,36 @@ function split_quoted_args() {
   printf '%s\n' "$parsed_file"
 }
 
+function get_installed_build_id() {
+  local manifest="${STEAMAPPDIR}/steamapps/appmanifest_${STEAMAPPID}.acf"
+
+  if [[ ! -f "${manifest}" ]]; then
+    echo "Warning: app manifest is unavailable at ${manifest}" >&2
+    return 1
+  fi
+
+  jq -Rn --rawfile acf "${manifest}" '
+    $acf
+    | capture("\"buildid\"\\s+\"(?<buildid>[0-9]+)\"").buildid
+  ' 2>/dev/null
+}
+
+# This flow intentionally targets the current `public` branch behavior only.
+# `UpToDateCheck` has no beta/branch selector.
+# `steamcmd +app_info_print` is intentionally avoided due to Valve issues:
+# https://github.com/ValveSoftware/steam-for-linux/issues/9683
+# https://github.com/ValveSoftware/steam-for-linux/issues/11521
+# Use Valve's documented `UpToDateCheck` API instead.
+function get_up_to_date_check() {
+  local installed_build_id="$1"
+
+  curl -fsS \
+    --get "${STEAM_UPTODATECHECK_API}" \
+    --data-urlencode "appid=${STEAMAPPID}" \
+    --data-urlencode "version=${installed_build_id}" \
+    --data-urlencode "format=json"
+}
+
 function download() {
 
   # Create App Dir
@@ -45,20 +75,6 @@ function download() {
   else
     # Dev Builds can not be auto updated
     AUTO_UPDATE="true"
-
-    # Get current buildid
-    local baseline_build_id=""
-    if baseline_build_id="$(curl -s "${STEAMCMD_API}/${STEAMAPPID}" | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")"; then
-        if [[ -n "$baseline_build_id" && "$baseline_build_id" != "null" ]]; then
-            STEAMPIPE_BUILD_ID="${baseline_build_id}"
-        else
-            echo "Warning: baseline BuildID is unavailable; auto-update will be disabled for this run."
-            AUTO_UPDATE="false"
-        fi
-    else
-        echo "Warning: failed to fetch baseline BuildID; auto-update will be disabled for this run."
-        AUTO_UPDATE="false"
-    fi
 
     # Else, download live build from Steam
     if [[ "$STEAMAPPVALIDATE" -eq 1 ]]; then
@@ -115,6 +131,13 @@ function download() {
     if [[ $steamcmd_rc != 0 ]]; then
         exit $steamcmd_rc
     fi
+
+    if STEAMPIPE_BUILD_ID="$(get_installed_build_id)"; then
+        echo "Installed Steam build ID: ${STEAMPIPE_BUILD_ID}"
+    else
+        echo "Warning: installed BuildID is unavailable; auto-update will be disabled for this run."
+        AUTO_UPDATE="false"
+    fi
   fi
 }
 
@@ -163,16 +186,31 @@ function start() {
     server_pid=$!
 
     while kill -0 "$server_pid" 2>/dev/null; do
-      sleep 1800 &
+      sleep "${STEAM_UPDATE_CHECK_INTERVAL_SECONDS}" &
       sleep_pid=$!
       wait "$sleep_pid" 2>/dev/null || true
-      local current_build_id=""
-      if current_build_id="$(curl -s "${STEAMCMD_API}/${STEAMAPPID}" | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")"; then
-        if [[ -n "$current_build_id" && "$current_build_id" != "null" && "$current_build_id" != "${STEAMPIPE_BUILD_ID}" ]]; then
-          echo "New BuildID is available, stopping server."
-          kill -TERM "$server_pid"
-          break
+      # Compare the locally installed public-branch build against Valve's current required version.
+      local up_to_date_check_response=""
+      if up_to_date_check_response="$(get_up_to_date_check "${STEAMPIPE_BUILD_ID}")"; then
+        local success=""
+        local up_to_date=""
+        local required_version=""
+        if ! success="$(jq -r '.response.success // empty' <<<"${up_to_date_check_response}")" \
+          || ! up_to_date="$(jq -r '.response.up_to_date // empty' <<<"${up_to_date_check_response}")" \
+          || ! required_version="$(jq -r '.response.required_version // empty' <<<"${up_to_date_check_response}")"; then
+          echo "Warning: failed to parse Steam UpToDateCheck response; continuing with current server process."
+        elif [[ "${success}" == "true" && "${up_to_date}" == "false" ]]; then
+          # Stopping on update is opt-in; restart behavior belongs to the container runtime or orchestrator.
+          if [[ "$RSDW_AUTO_STOP_ON_UPDATE" == "true" ]]; then
+            echo "New Steam version is available (installed=${STEAMPIPE_BUILD_ID}, required=${required_version}), stopping server."
+            kill -TERM "$server_pid"
+            break
+          else
+            echo "New Steam version is available (installed=${STEAMPIPE_BUILD_ID}, required=${required_version}), but RSDW_AUTO_STOP_ON_UPDATE is disabled; continuing to run current server."
+          fi
         fi
+      else
+        echo "Warning: failed to query Steam UpToDateCheck; continuing with current server process."
       fi
       sleep_pid=""
     done
@@ -191,6 +229,7 @@ function start() {
 ## Steamcmd debugging
 DEBUG="${DEBUG:-0}"
 STEAMAPPVALIDATE="${STEAMAPPVALIDATE:-0}"
+RSDW_AUTO_STOP_ON_UPDATE="${RSDW_AUTO_STOP_ON_UPDATE:-false}"
 
 if [[ "$DEBUG" -eq 1 ]] || [[ "$DEBUG" -eq 3 ]]; then
     STEAMCMD_SPEW="+set_spew_level 4 4"

--- a/sniper/app/entry.sh
+++ b/sniper/app/entry.sh
@@ -9,10 +9,30 @@ STEAM_DEPOT_BRANCH="public"
 
 # Functions
 
+function split_quoted_args() {
+  local input="$1"
+  local parsed_file=""
+
+  parsed_file=$(mktemp "${TMPDIR:-/tmp}/rsdw-quoted-args.XXXXXX") || {
+    echo "Error: failed to create temp file for quoted arguments" >&2
+    return 1
+  }
+
+  if [[ -n "$input" ]]; then
+    if ! printf '%s\n' "$input" | xargs -n1 printf '%s\n' > "$parsed_file"; then
+      echo "Error: failed to parse quoted arguments: ${input}" >&2
+      rm -f "$parsed_file"
+      return 1
+    fi
+  fi
+
+  printf '%s\n' "$parsed_file"
+}
+
 function download() {
 
   # Create App Dir
-  mkdir -p "${STEAMAPPDIR}" || true
+  mkdir -p "${STEAMAPPDIR}"
 
   # Download Game Server
   if [[ -n "$DEVBUILD_PRESIGNED_URL" ]]; then
@@ -27,7 +47,18 @@ function download() {
     AUTO_UPDATE="true"
 
     # Get current buildid
-    STEAMPIPE_BUILD_ID=$(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")
+    local baseline_build_id=""
+    if baseline_build_id="$(curl -s "${STEAMCMD_API}/${STEAMAPPID}" | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")"; then
+        if [[ -n "$baseline_build_id" && "$baseline_build_id" != "null" ]]; then
+            STEAMPIPE_BUILD_ID="${baseline_build_id}"
+        else
+            echo "Warning: baseline BuildID is unavailable; auto-update will be disabled for this run."
+            AUTO_UPDATE="false"
+        fi
+    else
+        echo "Warning: failed to fetch baseline BuildID; auto-update will be disabled for this run."
+        AUTO_UPDATE="false"
+    fi
 
     # Else, download live build from Steam
     if [[ "$STEAMAPPVALIDATE" -eq 1 ]]; then
@@ -39,8 +70,9 @@ function download() {
     ## SteamCMD can fail to download
     ## Retry logic
     MAX_ATTEMPTS=3
+    steamcmd_rc=1
     attempt=0
-    while [[ $steamcmd_rc != 0 ]] && [[ $attempt -lt $MAX_ATTEMPTS ]]; do
+    while (( steamcmd_rc != 0 && attempt < MAX_ATTEMPTS )); do
         ((attempt+=1))
         if [[ $attempt -gt 1 ]]; then
             echo "Retrying SteamCMD, attempt ${attempt}"
@@ -49,13 +81,34 @@ function download() {
             echo "Removing steamapps (appmanifest data)..."
             rm -rf "${STEAMAPPDIR}/steamapps"
         fi
-        eval bash "${STEAMCMDDIR}/steamcmd.sh" "${STEAMCMD_SPEW}"\
-                                    +force_install_dir "${STEAMAPPDIR}" \
-                                    +@bClientTryRequestManifestWithoutCode 1 \
-                                    +login anonymous \
-                                    +app_update "${STEAMAPPID}" "${VALIDATE}"\
-                                    +quit
-        steamcmd_rc=$?
+        local steamcmd_cmd=(bash "${STEAMCMDDIR}/steamcmd.sh")
+        local steamcmd_spew=()
+        if [[ -n "${STEAMCMD_SPEW:-}" ]]; then
+            local steamcmd_spew_file=""
+            if ! steamcmd_spew_file="$(split_quoted_args "${STEAMCMD_SPEW}")"; then
+                return 1
+            fi
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                steamcmd_spew+=("$line")
+            done < "${steamcmd_spew_file}"
+            rm -f "${steamcmd_spew_file}"
+            steamcmd_cmd+=("${steamcmd_spew[@]}")
+        fi
+        steamcmd_cmd+=(
+            +force_install_dir "${STEAMAPPDIR}"
+            +@bClientTryRequestManifestWithoutCode 1
+            +login anonymous
+            +app_update "${STEAMAPPID}"
+        )
+        if [[ -n "${VALIDATE}" ]]; then
+            steamcmd_cmd+=("${VALIDATE}")
+        fi
+        steamcmd_cmd+=(+quit)
+        if "${steamcmd_cmd[@]}"; then
+            steamcmd_rc=0
+        else
+            steamcmd_rc=$?
+        fi
     done
 
     ## Exit if steamcmd fails
@@ -87,26 +140,47 @@ function start() {
 
   echo "Launching RSDragonwildsServer.sh"
 
+  local server_cmd=(
+    bash "${STEAMAPPDIR}/RSDragonwildsServer.sh"
+    -Port "${RSDW_PORT}"
+  )
+  local additional_args=()
+
+  if [[ -n "${RSDW_ADDITIONAL_ARGS:-}" ]]; then
+    local additional_args_file=""
+    if ! additional_args_file="$(split_quoted_args "${RSDW_ADDITIONAL_ARGS}")"; then
+      exit 1
+    fi
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      additional_args+=("$line")
+    done < "${additional_args_file}"
+    rm -f "${additional_args_file}"
+    server_cmd+=("${additional_args[@]}")
+  fi
+
   if [[ "$AUTO_UPDATE" == "true" ]]; then
-    eval bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS} &
+    "${server_cmd[@]}" &
     server_pid=$!
 
     while kill -0 "$server_pid" 2>/dev/null; do
       sleep 1800 &
       sleep_pid=$!
       wait "$sleep_pid" 2>/dev/null || true
-      if [[ $(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid") == "${STEAMPIPE_BUILD_ID}" ]]; then
-        echo "New BuildID is available, stopping server."
-        kill -TERM "$server_pid"
-        break
+      local current_build_id=""
+      if current_build_id="$(curl -s "${STEAMCMD_API}/${STEAMAPPID}" | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")"; then
+        if [[ -n "$current_build_id" && "$current_build_id" != "null" && "$current_build_id" != "${STEAMPIPE_BUILD_ID}" ]]; then
+          echo "New BuildID is available, stopping server."
+          kill -TERM "$server_pid"
+          break
+        fi
       fi
       sleep_pid=""
     done
 
-    wait "$sever_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
     server_pid=""
   else
-    eval bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS}
+    "${server_cmd[@]}"
   fi
 }
 
@@ -115,19 +189,27 @@ function start() {
 # Debug handling
 
 ## Steamcmd debugging
-if [[ $DEBUG -eq 1 ]] || [[ $DEBUG -eq 3 ]]; then
+DEBUG="${DEBUG:-0}"
+STEAMAPPVALIDATE="${STEAMAPPVALIDATE:-0}"
+
+if [[ "$DEBUG" -eq 1 ]] || [[ "$DEBUG" -eq 3 ]]; then
     STEAMCMD_SPEW="+set_spew_level 4 4"
 fi
 ## RSDW server debugging
-if [[ $DEBUG -eq 2 ]] || [[ $DEBUG -eq 3 ]]; then
-    RSDW_LOG="on"
+if [[ "$DEBUG" -eq 2 ]] || [[ "$DEBUG" -eq 3 ]]; then
+    export RSDW_LOG="on"
 fi
 
 # FIX: steamclient.so fix
 mkdir -p ~/.steam/sdk64
-ln -sfT ${STEAMCMDDIR}/linux64/steamclient.so ~/.steam/sdk64/steamclient.so
+ln -sfT "${STEAMCMDDIR}/linux64/steamclient.so" ~/.steam/sdk64/steamclient.so
 
 # Parse Environment Variables
+
+## Bridge legacy additional arguments env var to canonical name
+if [[ -z "${RSDW_ADDITIONAL_ARGS:-}" && -n "${RSDW_ADDITIONAL_ARGUMENTS:-}" ]]; then
+  export RSDW_ADDITIONAL_ARGS="${RSDW_ADDITIONAL_ARGUMENTS}"
+fi
 
 # Ensure an Owner ID is set, as this is required
 if [[ -z "$RSDW_OWNER_ID" ]]; then
@@ -141,17 +223,17 @@ fi
 
 ## Generate random passwords, if required
 if [[ "$RSDW_PASSWORD" == "random" ]]; then
-  export RSDW_PASSWORD=$(pwgen -AB 12 1)
+  export RSDW_PASSWORD="$(pwgen -AB 12 1)"
   echo "RSDW_PASSWORD set to: ${RSDW_PASSWORD}"
 fi
 if [[ "$RSDW_ADMIN_PASSWORD" == "random" ]]; then
-  export RSDW_ADMIN_PASSWORD=$(pwgen -AB 12 1)
+  export RSDW_ADMIN_PASSWORD="$(pwgen -AB 12 1)"
   echo "RSDW_ADMIN_PASSWORD set to: ${RSDW_ADMIN_PASSWORD}"
 fi
 
 ## Check that World name is set
-if [[ -z $RSDW_WORLD_NAME ]]; then
-  export RSDW_WORLD_NAME=$(shuf -n 1 /etc/default/DedicatedServer.names)
+if [[ -z "${RSDW_WORLD_NAME}" ]]; then
+  export RSDW_WORLD_NAME="$(shuf -n 1 /etc/default/DedicatedServer.names)"
   echo "RSDW_WORLD_NAME set to: ${RSDW_WORLD_NAME}"
 fi
 
@@ -159,7 +241,7 @@ fi
 download
 
 # Template configuration file
-envsubst < /etc/default/DedicatedServer.ini > ${STEAMAPPDIR}/RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini
+envsubst < /etc/default/DedicatedServer.ini > "${STEAMAPPDIR}/RSDragonwilds/Saved/Config/LinuxServer/DedicatedServer.ini"
 
 # Switch to server directory
 cd "${STEAMAPPDIR}/RSDragonwilds/"

--- a/sniper/app/entry.sh
+++ b/sniper/app/entry.sh
@@ -27,7 +27,7 @@ function download() {
     AUTO_UPDATE="true"
 
     # Get current buildid
-    STEAMPIPE_BUILD_ID=$(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data.[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")
+    STEAMPIPE_BUILD_ID=$(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")
 
     # Else, download live build from Steam
     if [[ "$STEAMAPPVALIDATE" -eq 1 ]]; then
@@ -85,26 +85,28 @@ function start() {
 
   trap cleanup SIGINT SIGTERM
 
+  echo "Launching RSDragonwildsServer.sh"
+
   if [[ "$AUTO_UPDATE" == "true" ]]; then
-    eval /bin/bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS} &
+    eval bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS} &
     server_pid=$!
 
-    while kill -0 "$pid" 2>/dev/null; do
-      if [[ $(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data.[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid") == "${STEAMPIPE_BUILD_ID}" ]]; then
+    while kill -0 "$server_pid" 2>/dev/null; do
+      sleep 1800 &
+      sleep_pid=$!
+      wait "$sleep_pid" 2>/dev/null || true
+      if [[ $(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid") == "${STEAMPIPE_BUILD_ID}" ]]; then
         echo "New BuildID is available, stopping server."
         kill -TERM "$server_pid"
         break
       fi
-      sleep 1800 &
-      sleep_pid=$!
-      wait "$sleep_pid" 2>/dev/null || true
       sleep_pid=""
     done
 
     wait "$sever_pid" 2>/dev/null || true
     server_pid=""
   else
-    eval /bin/bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS}
+    eval bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS}
   fi
 }
 

--- a/sniper/app/entry.sh
+++ b/sniper/app/entry.sh
@@ -3,6 +3,10 @@
 # Exit script on failure
 set -e
 
+# Globals
+STEAMCMD_API="https://api.steamcmd.net/v1/info"
+STEAM_DEPOT_BRANCH="public"
+
 # Functions
 
 function download() {
@@ -12,10 +16,19 @@ function download() {
 
   # Download Game Server
   if [[ -n "$DEVBUILD_PRESIGNED_URL" ]]; then
+    # Dev Builds can not be auto updated
+    AUTO_UPDATE="false"
+
     # Download Dev build (zip archive) if URL provided
     curl -o build.zip "${DEVBUILD_PRESIGNED_URL}"
     unzip -o build.zip -d "${STEAMAPPDIR}"
   else
+    # Dev Builds can not be auto updated
+    AUTO_UPDATE="true"
+
+    # Get current buildid
+    STEAMPIPE_BUILD_ID=$(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data.[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid")
+
     # Else, download live build from Steam
     if [[ "$STEAMAPPVALIDATE" -eq 1 ]]; then
         VALIDATE="validate"
@@ -49,6 +62,48 @@ function download() {
     if [[ $steamcmd_rc != 0 ]]; then
         exit $steamcmd_rc
     fi
+  fi
+}
+
+function start() {
+  # Server start wrapper function
+  # When AUTO_UPDATE is "true" this function attempts to detect updates to the SteamPipe depot
+  # and will stop the server when a new version is available.
+  # Users are expected to couple this container with an orchestrator such as Systemd/Podman, EKS,
+  # or K8S, which will resurrect/restart the container automatically on exit.
+  local server_pid=""
+  local sleep_pid=""
+
+  cleanup() {
+    if [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null; then
+      kill -TERM "$server_pid" 2>/dev/null || true
+    fi
+    if [[ -n "$sleep_pid" ]] && kill -0 "$sleep_pid" 2>/dev/null; then
+      kill -TERM "$sleep_pid" 2>/dev/null || true
+    fi
+  }
+
+  trap cleanup SIGINT SIGTERM
+
+  if [[ "$AUTO_UPDATE" == "true" ]]; then
+    eval /bin/bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS} &
+    server_pid=$!
+
+    while kill -0 "$pid" 2>/dev/null; do
+      if [[ $(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data.[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid") == "${STEAMPIPE_BUILD_ID}" ]]; then
+        kill -TERM "$server_pid"
+        break
+      fi
+      sleep 1800 &
+      sleep_pid=$!
+      wait "$sleep_pid" 2>/dev/null || true
+      sleep_pid=""
+    done
+
+    wait "$sever_pid" 2>/dev/null || true
+    server_pid=""
+  else
+    eval /bin/bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS}
   fi
 }
 
@@ -110,4 +165,4 @@ cd "${STEAMAPPDIR}/RSDragonwilds/"
 /bin/chmod +x "${STEAMAPPDIR}/RSDragonwilds/Plugins/Developer/Sentry/Binaries/Linux/crashpad_handler"
 
 # Start Server
-/bin/bash ${STEAMAPPDIR}/RSDragonwildsServer.sh -Port ${RSDW_PORT} ${RSDW_ADDITIONAL_ARGUMENTS}
+start

--- a/sniper/app/entry.sh
+++ b/sniper/app/entry.sh
@@ -91,6 +91,7 @@ function start() {
 
     while kill -0 "$pid" 2>/dev/null; do
       if [[ $(curl -s ${STEAMCMD_API}/${STEAMAPPID} | jq -r ".data.[\"${STEAMAPPID}\"]?.depots.branches.${STEAM_DEPOT_BRANCH}.buildid") == "${STEAMPIPE_BUILD_ID}" ]]; then
+        echo "New BuildID is available, stopping server."
         kill -TERM "$server_pid"
         break
       fi


### PR DESCRIPTION
## Summary

  - replace the rudimentary Steam update check with a Valve-backed ISteamApps/UpToDateCheck flow
  - harden the dedicated server entry-point and supporting image layers
  - add an opt-in RSDW_AUTO_STOP_ON_UPDATE toggle so update detection does not stop running servers by default

## User Impact

  - Steam-installed servers can now detect newer builds using Valve’s API rather than an unofficial SteamCMD mirror
  - update detection no longer implies automatic shutdown by default
  - users who want automatic roll-forward behaviour can opt in with:
      - RSDW_AUTO_STOP_ON_UPDATE=true